### PR TITLE
Upgrade flash-store from 0.16 to 0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padplus",
-  "version": "0.3.17",
+  "version": "0.3.20",
   "description": "Puppet Padplus for Wechaty",
   "directories": {
     "test": "tests"
@@ -74,7 +74,7 @@
     "aws-sdk": "^2.510.0",
     "axios": "^0.19.0",
     "brolog": "^1.6.5",
-    "flash-store": "^0.16.13",
+    "flash-store": "^0.18.12",
     "form-data": "^3.0.0",
     "fs-extra": "^8.1.0",
     "google-protobuf": "^3.6.1",


### PR DESCRIPTION
We should not use v0.16 because it's buggy.

Related to: https://github.com/huan/flash-store/issues/50