### PR TITLE
Error message typo: image -> message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padplus",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "Puppet Padplus for Wechaty",
   "directories": {
     "test": "tests"

--- a/src/puppet-padplus.ts
+++ b/src/puppet-padplus.ts
@@ -1155,7 +1155,11 @@ export class PuppetPadplus extends Puppet {
     }
     rawPayload = await this.manager.cacheManager.getMessage(messageId)
     if (!rawPayload) {
-      throw new Error('no message rawPayload for image')
+      log.error('PuppetPadplus', 'messageRawPayload(%s) manager.cacheManager.getMessage(%s) return nothing.',
+        messageId,
+        messageId,
+      )
+      throw new Error('no message rawPayload for message id ' + messageId)
     }
     return rawPayload
   }


### PR DESCRIPTION
BTW: we should make sure that when we give a message-id, we can always get the payload of it.

```
11:41:52 INFO Chatops roomMessage(17376996519@chatroom, 💪)
11:41:52 VERB Room ready()
11:41:52 VERB StateSwitch <WechatyReady> on(true) <- (false)
11:41:52 VERB Room say(💪, )
11:41:53 VERB Message static load(7848294574682324097)
11:41:53 VERB Message constructor(7848294574682324097) for class Message
11:41:53 VERB Message ready()
11:41:53 VERB Room ready()
11:42:09 VERB Message static load([object Object])
11:42:09 VERB Message constructor([object Object]) for class Message
11:42:09 VERB Message ready()
11:42:09 ERR Config ###########################
11:42:09 ERR Config unhandledRejection: Error: no message rawPayload for image [object Promise]
11:42:09 ERR Config ###########################
11:42:09 ERR Config process.on(unhandledRejection) promise.catch(no message rawPayload for image)
Config Error: no message rawPayload for image
    at PuppetPadplus.<anonymous> (/app/node_modules/wechaty/node_modules/wechaty-puppet-padplus/src/puppet-padplus.ts:1158:13)
    at Generator.next (<anonymous>)
    at fulfilled (/app/node_modules/wechaty/node_modules/wechaty-puppet-padplus/dist/src/puppet-padplus.js:5:58)
(node:4) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 56)
11:42:29 VERB Message static load([object Object])
11:42:29 VERB Message constructor([object Object]) for class Message
11:42:29 VERB Message ready()
11:42:29 ERR Config ###########################
11:42:29 ERR Config unhandledRejection: Error: no message rawPayload for image [object Promise]
11:42:29 ERR Config ###########################
11:42:29 ERR Config process.on(unhandledRejection) promise.catch(no message rawPayload for image)
Config Error: no message rawPayload for image
    at PuppetPadplus.<anonymous> (/app/node_modules/wechaty/node_modules/wechaty-puppet-padplus/src/puppet-padplus.ts:1158:13)
    at Generator.next (<anonymous>)
    at fulfilled (/app/node_modules/wechaty/node_modules/wechaty-puppet-padplus/dist/src/puppet-padplus.js:5:58)
(node:4) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 59)
```

Update: at Mar 16 20:15, the friday bot down, with this Error.