### PR TITLE
fix:upgrade wechaty-puppet-cache version to add prefix to table name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padplus",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Puppet Padplus for Wechaty",
   "directories": {
     "test": "tests"
@@ -82,7 +82,7 @@
     "state-switch": "^0.9.7",
     "uuid": "^7.0.0",
     "watchdog": "^0.8.10",
-    "wechaty-puppet-cache": "^0.1.6",
+    "wechaty-puppet-cache": "^0.1.7",
     "xml2js": "^0.4.22"
   },
   "publishConfig": {

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,10 @@ const puppet: Puppet = new PuppetPadplus({
 
 ```
 
+#### Caution
+
+*When you use mongo as cache store, wechaty-puppet-cache use some tables which have ```wechaty-cache``` prefix. [detail>>](https://www.npmjs.com/package/wechaty-puppet-cache#4-caution)*
+
 ### 6. Other Tips
 
 > Set environment in windows

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ const puppet: Puppet = new PuppetPadplus({
 
 #### Caution
 
-*When you use mongo as cache store, wechaty-puppet-cache use some tables which have ```wechaty-cache``` prefix. [detail>>](https://www.npmjs.com/package/wechaty-puppet-cache#4-caution)*
+*When you use mongo as cache store, wechaty-puppet-cache use some tables which have `wechaty-cache` prefix. [detail>>](https://www.npmjs.com/package/wechaty-puppet-cache#4-caution)*
 
 ### 6. Other Tips
 


### PR DESCRIPTION
1. upgrade wechaty-puppet-cache version to add prefix to table name when using Mongo as cache store

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
