### PR TITLE
fix:upgrade wechaty-puppet-cache version to fix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "state-switch": "^0.9.7",
     "uuid": "^7.0.0",
     "watchdog": "^0.8.10",
-    "wechaty-puppet-cache": "^0.1.7",
+    "wechaty-puppet-cache": "^0.1.9",
     "xml2js": "^0.4.22"
   },
   "publishConfig": {


### PR DESCRIPTION
1. fix wechaty-puppet-cache can not get keys,values,entries when use flash-store as store

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
