### PR TITLE
fix:downgrade wechaty-puppet-cache version to keep flash-store version in wechaty-puppet-cache same to in wechaty-puppet-padplus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padplus",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Puppet Padplus for Wechaty",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "state-switch": "^0.9.7",
     "uuid": "^7.0.0",
     "watchdog": "^0.8.10",
-    "wechaty-puppet-cache": "^0.1.9",
+    "wechaty-puppet-cache": "^0.1.10",
     "xml2js": "^0.4.22"
   },
   "publishConfig": {


### PR DESCRIPTION
1. downgrade wechaty-puppet-cache version to keep flash-store version in wechaty-puppet-cache same to in wechaty-puppet-padplus

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
